### PR TITLE
fix the drag position problem when existing non draggable elements at the end of the list

### DIFF
--- a/src/Sortable.js
+++ b/src/Sortable.js
@@ -1188,7 +1188,12 @@ Sortable.prototype = /** @lends Sortable.prototype */ {
 
 				if (onMove(rootEl, el, dragEl, dragRect, target, targetRect, evt, !!target) !== false) {
 					capture();
-					el.appendChild(dragEl);
+					if (elLastChild && elLastChild.nextSibling) { // the last draggable element is not the last node
+						el.insertBefore(dragEl, elLastChild.nextSibling);
+					}
+					else {
+						el.appendChild(dragEl);
+					}
 					parentEl = el; // actualization
 
 					changed();


### PR DESCRIPTION

When dragging an element to the end of the list, and existing non draggable elements at the end of the list.  Appending it to the end of the list is not incorrect, It should be inserted before the next sibling of the last draggable element.